### PR TITLE
Added python-muranoclient to requirements

### DIFF
--- a/requirements-eggs.txt
+++ b/requirements-eggs.txt
@@ -23,6 +23,7 @@ pip==1.2.1
 psycopg2==2.4.6
 pycrypto==2.6
 python-heatclient==0.2.2
+python-muranoclient==0.2
 simplejson==2.6.2
 six==1.1.0
 tornado==3.0


### PR DESCRIPTION
It required for OSPF automated tests for OpenStack Murano project.
