### PR TITLE
Update of devops requirement

### DIFF
--- a/fuelweb_test/requirements.txt
+++ b/fuelweb_test/requirements.txt
@@ -1,4 +1,4 @@
 nose==1.2.1
-git+ssh://git@github.com/Mirantis/devops.git@fcaf0931dc850e9742b4b6a28681e6cdef7c0f83
+git+https://github.com/Mirantis/devops.git@2.1
 anyjson==0.3.1
 paramiko==1.10.1


### PR DESCRIPTION
1. Use version tag instead of commit_id
2. Use git+https instead git+ssh for setup devops w/o
   github.com/Mirantis git+ssh access
